### PR TITLE
prepare for ZF3, replaced 'invokables'

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -27,8 +27,11 @@ return array(
         ),
     ),
     'controllers' => array(
-        'invokables' => array(
+        'aliases' => array(
             'Application\Controller\Index' => 'Application\Controller\IndexController',
+        ),
+        'factories' => array(
+            'Application\Controller\IndexController' => 'Zend\ServiceManager\Factory\InvokableFactory',
         ),
     ),
     'view_manager' => array(


### PR DESCRIPTION
replaced `invokables` in favour of `aliases` and `factories`, according to the [migration guide](https://zendframework.github.io/zend-servicemanager/migration/#invokables) 
